### PR TITLE
Removed custom checks for AWS auth data

### DIFF
--- a/src/SA/CpeClientSdk.php
+++ b/src/SA/CpeClientSdk.php
@@ -89,12 +89,6 @@ class CpeClientSdk
      */
     public function __construct($key = false, $secret = false, $region = false, $debug = false)
     {
-        if (!$key &&
-            !($key = getenv("AWS_ACCESS_KEY_ID")))
-            throw new \Exception("Set 'AWS_ACCESS_KEY_ID' environment variable!");
-        if (!$secret &&
-            !($secret = getenv("AWS_SECRET_KEY")))
-            throw new \Exception("Set 'AWS_SECRET_KEY' environment variable!");
         if (!$region &&
             !($region = getenv("AWS_DEFAULT_REGION")))
             throw new \Exception("Set 'AWS_DEFAULT_REGION' environment variable!");


### PR DESCRIPTION
There were some checks for environment variables in the Swf handler
class, which causes anything using the class to fatal error out, even if
valid credentials are supplied to the client via another method.

Removed the credentials check, as the aws-php-sdk library will check for
credentials on its own anyway.
